### PR TITLE
Add PanningMode to ScrollViewer in Generic.xaml to be able to Scroll via touch input

### DIFF
--- a/Source/Themes/Generic.xaml
+++ b/Source/Themes/Generic.xaml
@@ -105,7 +105,7 @@
                     <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
                         <DockPanel>
                             <Control DockPanel.Dock="Top" Template="{TemplateBinding TitleControl}" />
-                            <ScrollViewer x:Name="KB_ScrollViewer" Focusable="False">
+                            <ScrollViewer x:Name="KB_ScrollViewer" Focusable="False" PanningMode="Both">
                                 <StackPanel>
                                     <local:KanbanBoardGridPanel MinHeight="{Binding ActualHeight, ElementName=KB_ScrollViewer}" Columns="{TemplateBinding Columns}" Swimlanes="{TemplateBinding Swimlanes}" />
                                     <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />

--- a/Source/WPF-Kanban.csproj
+++ b/Source/WPF-Kanban.csproj
@@ -9,7 +9,7 @@
     <Product>WPF-Kanban</Product>
     <Description>A simple task board WPF control</Description>
     <Copyright>Copyright 2025</Copyright>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
     <Authors>Khaos-Coders</Authors>


### PR DESCRIPTION
This pull request makes a small update to the `Source/Themes/Generic.xaml` file by enabling panning in both directions for the `ScrollViewer` used in the Kanban board template.

- UI/Scrolling:
  * Set `PanningMode="Both"` on the `KB_ScrollViewer` `ScrollViewer` to allow both horizontal and vertical panning, improving touch and mouse scrolling support.